### PR TITLE
Support no autoincrement

### DIFF
--- a/columns/columns.go
+++ b/columns/columns.go
@@ -13,7 +13,12 @@ type Columns struct {
 	lock       *sync.RWMutex
 	TableName  string
 	TableAlias string
-	IDField    string
+	IDField    IDField
+}
+
+type IDField struct {
+	Name      string
+	Writeable bool
 }
 
 // Add a column to the list.
@@ -75,7 +80,7 @@ func (c *Columns) Add(names ...string) []*Column {
 				} else if xs[1] == "w" {
 					col.Readable = false
 				}
-			} else if col.Name == c.IDField {
+			} else if col.Name == c.IDField.Name && c.IDField.Writeable == false {
 				col.Writeable = false
 			}
 
@@ -158,13 +163,13 @@ func (c Columns) SymbolizedString() string {
 }
 
 // NewColumns constructs a list of columns for a given table name.
-func NewColumns(tableName, idField string) Columns {
+func NewColumns(tableName string, idField IDField) Columns {
 	return NewColumnsWithAlias(tableName, "", idField)
 }
 
 // NewColumnsWithAlias constructs a list of columns for a given table
 // name, using a given alias for the table.
-func NewColumnsWithAlias(tableName, tableAlias, idField string) Columns {
+func NewColumnsWithAlias(tableName, tableAlias string, idField IDField) Columns {
 	return Columns{
 		lock:       &sync.RWMutex{},
 		Cols:       map[string]*Column{},

--- a/columns/columns_for_struct.go
+++ b/columns/columns_for_struct.go
@@ -7,12 +7,12 @@ import (
 // ForStruct returns a Columns instance for
 // the struct passed in.
 func ForStruct(s interface{}, tableName, idField string) (columns Columns) {
-	return ForStructWithAlias(s, tableName, "", idField)
+	return ForStructWithAlias(s, tableName, "", IDField{Name: idField})
 }
 
 // ForStructWithAlias returns a Columns instance for the struct passed in.
 // If the tableAlias is not empty, it will be used.
-func ForStructWithAlias(s interface{}, tableName, tableAlias, idField string) (columns Columns) {
+func ForStructWithAlias(s interface{}, tableName, tableAlias string, idField IDField) (columns Columns) {
 	columns = NewColumnsWithAlias(tableName, tableAlias, idField)
 	defer func() {
 		if r := recover(); r != nil {

--- a/columns/columns_test.go
+++ b/columns/columns_test.go
@@ -115,3 +115,14 @@ func Test_Columns_ID_Field_Not_ID(t *testing.T) {
 	r.Equal(1, len(c.Cols), "%+v", c)
 	r.Equal(&columns.Column{Name: "notid", Writeable: false, Readable: true, SelectSQL: "non_standard_id.notid"}, c.Cols["notid"])
 }
+
+func Test_Columns_IDField_NoAutoIncrement(t *testing.T) {
+	type withIDNoAutoIncrement struct {
+		ID int `db:"id" no_auto_increment:"true"`
+	}
+
+	r := require.New(t)
+	c := columns.ForStructWithAlias(withIDNoAutoIncrement{ID: 2}, "with_id_no_auto_increment", "", columns.IDField{Name: "id", Writeable: true})
+	r.Equal(1, len(c.Cols), "%+v", c)
+	r.Equal(&columns.Column{Name: "id", Writeable: true, Readable: true, SelectSQL: "with_id_no_auto_increment.id"}, c.Cols["id"])
+}

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -50,7 +50,9 @@ func genericCreate(c *Connection, model *Model, cols columns.Columns, quoter quo
 	switch keyType {
 	case "int", "int64":
 		var id int64
-		cols.Remove(model.IDField())
+		if model.UsingAutoIncrement() {
+			cols.Remove(model.IDField())
+		}
 		w := cols.Writeable()
 		query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quoter.Quote(model.TableName()), w.QuotedString(quoter), w.SymbolizedString())
 		txlog(logging.SQL, c, query, model.Value)
@@ -58,12 +60,15 @@ func genericCreate(c *Connection, model *Model, cols columns.Columns, quoter quo
 		if err != nil {
 			return err
 		}
-		id, err = res.LastInsertId()
-		if err == nil {
-			model.setID(id)
-		}
-		if err != nil {
-			return err
+		// If the model isn't using auto_increment, the id is already set
+		if model.UsingAutoIncrement() {
+			id, err = res.LastInsertId()
+			if err == nil {
+				model.setID(id)
+			}
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	case "UUID", "string":

--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -58,7 +58,9 @@ func (p *postgresql) Create(c *Connection, model *Model, cols columns.Columns) e
 	}
 	switch keyType {
 	case "int", "int64":
-		cols.Remove(model.IDField())
+		if model.UsingAutoIncrement() {
+			cols.Remove(model.IDField())
+		}
 		w := cols.Writeable()
 		var query string
 		if len(w.Cols) > 0 {

--- a/executors.go
+++ b/executors.go
@@ -362,7 +362,7 @@ func (c *Connection) Update(model interface{}, excludeColumns ...string) error {
 			}
 
 			tn := m.TableName()
-			cols := columns.ForStructWithAlias(model, tn, m.As, m.IDField())
+			cols := columns.ForStructWithAlias(model, tn, m.As, columns.IDField{Name: m.IDField(), Writeable: !m.UsingAutoIncrement()})
 			cols.Remove(m.IDField(), "created_at")
 
 			if tn == sm.TableName() {
@@ -401,7 +401,7 @@ func (q *Query) UpdateQuery(model interface{}, columnNames ...string) (int64, er
 		return 0, fmt.Errorf("model must be a struct; got %s", modelKind)
 	}
 
-	cols := columns.NewColumnsWithAlias(sm.TableName(), sm.As, sm.IDField())
+	cols := columns.NewColumnsWithAlias(sm.TableName(), sm.As, columns.IDField{Name: sm.IDField(), Writeable: !sm.UsingAutoIncrement()})
 	cols.Add(columnNames...)
 	if _, err := sm.fieldByName("UpdatedAt"); err == nil {
 		cols.Add("updated_at")
@@ -435,11 +435,11 @@ func (c *Connection) UpdateColumns(model interface{}, columnNames ...string) err
 
 			cols := columns.Columns{}
 			if len(columnNames) > 0 && tn == sm.TableName() {
-				cols = columns.NewColumnsWithAlias(tn, m.As, sm.IDField())
+				cols = columns.NewColumnsWithAlias(tn, m.As, columns.IDField{Name: sm.IDField(), Writeable: !sm.UsingAutoIncrement()})
 				cols.Add(columnNames...)
 
 			} else {
-				cols = columns.ForStructWithAlias(model, tn, m.As, m.IDField())
+				cols = columns.ForStructWithAlias(model, tn, m.As, columns.IDField{Name: m.IDField(), Writeable: !m.UsingAutoIncrement()})
 			}
 			cols.Remove("id", "created_at")
 

--- a/executors_test.go
+++ b/executors_test.go
@@ -2008,3 +2008,25 @@ func Test_Create_Timestamps_With_NowFunc(t *testing.T) {
 		r.Equal(fakeNow, friend.UpdatedAt)
 	})
 }
+
+func Test_Update_Non_Auto_Increment_ID(t *testing.T) {
+	if PDB == nil {
+		t.Skip("skipping integration tests")
+	}
+	transaction(func(tx *Connection) {
+		r := require.New(t)
+
+		firstID := 2
+		client := &UpstreamCopyWithoutAutoIncrement{
+			ID: firstID,
+		}
+		r.NoError(tx.Create(client))
+		r.Equal(firstID, client.ID)
+
+		updatedID := 4
+		client.ID = updatedID
+		r.NoError(tx.Update(client))
+		r.NoError(tx.Reload(client))
+		r.Equal(updatedID, client.ID)
+	})
+}

--- a/model.go
+++ b/model.go
@@ -87,7 +87,7 @@ func (m *Model) PrimaryKeyType() (string, error) {
 
 // UsingAutoIncrement returns true if the model is not opting out of autoincrement
 func (m *Model) UsingAutoIncrement() bool {
-	tag, err := m.tagForFieldByName(m.IDField(), "no_auto_increment")
+	tag, err := m.tagForFieldByName(strings.ToUpper(m.IDField()), "no_auto_increment")
 	// if there is no `no_auto_increment` tag, or tag isn't true, then we default to relying on auto increment
 	return err != nil || tag != "true"
 }

--- a/model_test.go
+++ b/model_test.go
@@ -214,3 +214,39 @@ func Test_WhereID(t *testing.T) {
 	m = Model{Value: &testNormalID{ID: 1}}
 	r.Equal("id", m.IDField())
 }
+
+type testNoAutoincrement struct {
+	ID        int `db:"id" no_auto_increment:"true"`
+	CreatedAt int `db:"created_at"`
+	UpdatedAt int `db:"updated_at"`
+}
+
+func (t testNoAutoincrement) TableName() string {
+	return "foo.bar"
+}
+
+func Test_NoAutoIncrementID(t *testing.T) {
+	r := require.New(t)
+	m := NewModel(&testNoAutoincrement{ID: 1}, context.Background())
+
+	r.Equal("foo_bar.id = ?", m.WhereID())
+	r.Equal(false, m.UsingAutoIncrement())
+}
+
+type testUsingAutoincrementByDefault struct {
+	ID        int `db:"id"`
+	CreatedAt int `db:"created_at"`
+	UpdatedAt int `db:"updated_at"`
+}
+
+func (t testUsingAutoincrementByDefault) TableName() string {
+	return "foo.bar"
+}
+
+func Test_UsingAutoIncrementByDefaultID(t *testing.T) {
+	r := require.New(t)
+	m := NewModel(&testUsingAutoincrementByDefault{ID: 1}, context.Background())
+
+	r.Equal("foo_bar.id = ?", m.WhereID())
+	r.Equal(true, m.UsingAutoIncrement())
+}

--- a/pop_test.go
+++ b/pop_test.go
@@ -493,3 +493,9 @@ type EmbeddingStruct struct {
 	InnerStruct
 	AdditionalField string `db:"additional_field"`
 }
+
+type UpstreamCopyWithoutAutoIncrement struct {
+	ID        int       `db:"id" no_auto_increment:"true"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}

--- a/sql_builder.go
+++ b/sql_builder.go
@@ -255,7 +255,7 @@ func (sq *sqlBuilder) buildColumns() columns.Columns {
 		if ok && cols.TableAlias == asName {
 			return cols
 		}
-		cols = columns.ForStructWithAlias(sq.Model.Value, tableName, asName, sq.Model.IDField())
+		cols = columns.ForStructWithAlias(sq.Model.Value, tableName, asName, columns.IDField{Name: sq.Model.IDField(), Writeable: !sq.Model.UsingAutoIncrement()})
 		columnCacheMutex.Lock()
 		columnCache[tableName] = cols
 		columnCacheMutex.Unlock()
@@ -263,7 +263,7 @@ func (sq *sqlBuilder) buildColumns() columns.Columns {
 	}
 
 	// acl > 0
-	cols := columns.NewColumns("", sq.Model.IDField())
+	cols := columns.NewColumns("", columns.IDField{Name: sq.Model.IDField(), Writeable: !sq.Model.UsingAutoIncrement()})
 	cols.Add(sq.AddColumns...)
 	return cols
 }


### PR DESCRIPTION
Supports tables that dont have auto increment.

Enable on a table by adding `no_auto_increment:"true"` to the struct tags on the id field

```
type MyModel struct {
  ID int `db:"id" no_auto_increment:"true"`
}
```

This is needed to support upstream copies of tables that need to ensure their primary key is correctly copied from the downstream table, even in cases where the copies may be added out of order or missing some entries.